### PR TITLE
link fixes for blog articles; especially for the aws repo reorganization

### DIFF
--- a/content/post/openemr-availabile-on-aws.md
+++ b/content/post/openemr-availabile-on-aws.md
@@ -23,8 +23,8 @@ tags:
   - Cloud
 ---
 
-[Setup Guide](https://github.com/openemr/openemr-devops/tree/master/stacks/AWS-full-stack)
-[CloudFormation Template](https://github.com/openemr/openemr-devops/blob/master/stacks/AWS-full-stack/assets/OpenEMR.json)
+[Setup Guide](https://github.com/openemr/openemr-devops/tree/master/packages/full_stack#openemr-cloud-full-stack)
+[CloudFormation Template](https://github.com/openemr/openemr-devops/blob/master/packages/full_stack/assets/OpenEMR.json)
 
 OpenEMR Cloud Full Stack, a cloud service version of
 [OpenEMR](http://open-emr.org) - the most popular open source electronic health
@@ -66,7 +66,7 @@ required.
 
 With only a few simple steps, including specification of OpenEMR Cloud Full
 Stack's [CloudFormation
-template](https://github.com/openemr/openemr-devops/blob/master/stacks/AWS-full-stack/assets/OpenEMR.json),
+template](https://github.com/openemr/openemr-devops/blob/master/packages/full_stack/assets/OpenEMR.json),
 healthcare providers "spin up" their own full stack instance of OpenEMR in the
 cloud. Customizations are tested and deployed with ease, with OpenEMR Cloud's
 continuous deployment model.
@@ -128,7 +128,7 @@ AWS's Business Associate services.
 The OpenEMR Community's choice of industry leading AWS is a testament to AWS
 leadership in cloud technology and total cost of application ownership. To get
 started with OpenEMR Cloud Full stack, please visit its [Setup
-Guide](https://github.com/openemr/openemr-devops/tree/master/stacks/AWS-full-stack).
+Guide](https://github.com/openemr/openemr-devops/tree/master/packages/full_stack#openemr-cloud-full-stack).
 
 #### About OpenEMR
 

--- a/content/post/openemr-installations-support-puerto-rico.md
+++ b/content/post/openemr-installations-support-puerto-rico.md
@@ -67,7 +67,7 @@ maintain all of the prestigious [American Health Information Managers
 Association's (AHIMA)](http://www.ahima.org/) Certified Healthcare Technical
 Support credentials, HITECH Compliance is proud to be a [Certified OpenEMR
 Professional Support
-Provider](http://open-emr.org/wiki/index.php/Professional_Support#HITECH_Compliance.)
+Provider](http://open-emr.org/wiki/index.php/Professional_Support#HITECH_Compliance)
 and Contributor.
 
 <small class="text-muted">[Cover photo ("Sailors treat a patient in casualty


### PR DESCRIPTION
@robertdown ,
This fixes some links with the blogs (especially for the aws package link reorg that just happened). I don't want to push this since I don't want to be responsible for killing the blog while you are doing the hackathon. Let me know if it's ok and I'll bring it in, though.

Priority wise, the hackathon is much more important than these links, and these links can definitely wait until after hackathon is done, if necessary.